### PR TITLE
fix: correct PRNG lap count for block-aligned saves

### DIFF
--- a/MandarinJuiceCore/Helpers/MandarinDeencryptor.cs
+++ b/MandarinJuiceCore/Helpers/MandarinDeencryptor.cs
@@ -338,8 +338,12 @@ public class MandarinDeencryptor(ulong mandarinSeed = 0)
     {
         const byte shift = 0xE;
         var mandarinQueue = new MandarinSlicesQueue(shift);
+        
+        // Current:
+        // var laps = (dataLength >> shift) + 1;
 
-        var laps = (dataLength >> shift) + 1;
+        // Proposed fix:
+        var laps = (dataLength + 0x3FFF) >> shift;
 
         for (var i = 0; i < laps; i++)
         {


### PR DESCRIPTION
Hey, I think I found the cause of the MH: Wilds saves being corrupted/having possibly wrong checksum on block 1 after resigning.

It's a follow-up on this issue: #8 

I was comparing MandarinJuice against ree-save-editor and found a one-line difference in CalculateSlicesQueue:

```csharp
// Current
var laps = (dataLength >> shift) + 1;

// Fix
var laps = (dataLength + 0x3FFF) >> shift;
```

The current formula adds an extra PRNG roll when the compressed save size is an exact multiple of 0x4000 (16KB). That extra splitmix shifts the entire state before any block gets processed, so the AES key derivation is wrong and the checksum fails.

I confirmed this by resigning the same save with my own tool (which uses the corrected formula) and ree-save-editor validates it fine. MandarinJuice resigned version hard fails at block 1 checksum. This isn't Wilds-specific either, any game whose compressed save happens to land on an exact 16KB boundary would hit this.

The issue thread, has some of the test files there as of my latest comment over there.